### PR TITLE
Small and very confusing typo in the plugin warning

### DIFF
--- a/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/diagnostics/checkers/WasmJsEnvironmentChecker.kt
+++ b/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/diagnostics/checkers/WasmJsEnvironmentChecker.kt
@@ -16,7 +16,7 @@ internal object WasmJsEnvironmentChecker : JsLikeEnvironmentChecker(
     listOf(
         "browser()",
         "nodejs()",
-        "d8"
+        "d8()"
     ),
     listOf(
         { it.browserNotConfigured() },


### PR DESCRIPTION
### What's done:
- Invalid suggestion in warning confuses Kotlin newbies